### PR TITLE
Silent errors fix, Error handling callback & Configurable max key/value buffer sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,10 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 cmake-build-debug
+/build/
+
+# Clang ignores
+/.cache/clangd
 
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -35,18 +35,23 @@ struct Person {
     char *name; 
     int age; 
 };
+static int callback(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    if (error) {
+        fprintf(stderr, "Error: %s\n", error);
+        return 1;
+    }
 
-static void callback(const char *const key, const char *const value, const char *const parentKey, void *object) {
     struct Person *person = object;
     if (strcmp(key, "name") == 0) (*person).name = strdup(value);
     if (strcmp(key, "age") == 0) (*person).age = atoi(value);
+    return 0;
 }
 
 int main(void) {
     char *json = "{\"name\": \"John Doe\", \"age\": 25}";
     
     struct Person person = (struct Person){0};
-    nanojsonc_parse_object(json, callback, NULL, &person);
+    nanojsonc_parse_object(json, callback, NULL, &person, NULL);
     printf("Name: %s, Age: %d", person.name, person.age); // Name: John Doe, Age: 25
     
     free(person.name);
@@ -61,7 +66,12 @@ struct Hobby {
     struct Hobby *next;
 };
 
-static void callback(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    if (error) {
+        fprintf(stderr, "Error: %s\n", error);
+        return 1;
+    }
+
     struct Hobby **hobbies = object;
     
     struct Hobby *hobby = malloc(sizeof(struct Hobby));
@@ -72,6 +82,8 @@ static void callback(const char *const key, const char *const value, const char 
     for (cursor = hobbies; *cursor; cursor = &(*cursor)->next);
     
     *cursor = hobby;
+
+    return 0;
 }
 
 int main(void) {

--- a/example/example1.c
+++ b/example/example1.c
@@ -40,7 +40,12 @@ struct Person {
     int age;
 };
 
-static void callback(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    if (error) {
+        fprintf(stderr, "Error: %s\n", error);
+        return 1;
+    }
+    
     struct Person **person = object;
     if (*person == NULL) {
         *person = malloc(sizeof(struct Person));
@@ -48,6 +53,7 @@ static void callback(const char *const key, const char *const value, const char 
     }
     if (strcmp(key, "name") == 0) (*person)->name = strdup(value);
     if (strcmp(key, "age") == 0) (*person)->age = atoi(value);
+    return 0;
 }
 
 int main(void) {

--- a/example/example2.c
+++ b/example/example2.c
@@ -40,7 +40,12 @@ struct Hobby {
     struct Hobby *next;
 };
 
-static void callback(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    if (error) {
+        fprintf(stderr, "Error: %s\n", error);
+        return 1;
+    }
+    
     struct Hobby **hobbies = object;
 
     struct Hobby *hobby = malloc(sizeof(struct Hobby));
@@ -51,6 +56,7 @@ static void callback(const char *const key, const char *const value, const char 
     for (cursor = hobbies; *cursor; cursor = &(*cursor)->next);
 
     *cursor = hobby;
+    return 0;
 }
 
 int main(void) {

--- a/example/example3.c
+++ b/example/example3.c
@@ -63,7 +63,11 @@ struct Person {
     } *children;
 };
 
-static void callback(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    if (error) {
+        fprintf(stderr, "Error: %s\n", error);
+        return 1;
+    }
     struct Person **person = object;
 
     if (*person == NULL) {
@@ -140,6 +144,8 @@ static void callback(const char *const key, const char *const value, const char 
             (*cursor)->age = atoi(value);
         }
     }
+
+    return 0;
 }
 
 void verify(struct Person *person) {

--- a/include/parser.h
+++ b/include/parser.h
@@ -37,8 +37,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef NANOJSONC_PARSER_H
 #define NANOJSONC_PARSER_H
 
-#define KEY_SIZE	128
-#define VALUE_SIZE	1024
+#ifndef NANOJSONC_KEY_SIZE
+#define NANOJSONC_KEY_SIZE 128
+#endif
+
+#ifndef NANOJSONC_VALUE_SIZE
+#define NANOJSONC_VALUE_SIZE	1024
+#endif
+
+typedef int (*NanoJSONcCallback)(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object);
 
 /**
  * @brief Parse a JSON array and invoke a callback for each element.
@@ -55,16 +62,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * The callback function should have the following signature:
  * @code
- * void callback(const char *const key, const char *const value,
- *               const char *const parentKey, void *object);
+ * int callback(const char *const error, const char *const key, 
+ *               const char *const value, const char *const parentKey, void *object);
  * @endcode
  *
  * @note The provided callback function should handle the processing or population
- *       of the object based on the parsed JSON elements.
+ *       of the object based on the parsed JSON elements. If the callback returns
+ *       a non-zero value, the parsing process will be aborted.
  *
  * @see nanojsonc_parse_object
  */
-void nanojsonc_parse_array(const char *json, void (*callback)(const char *const key, const char *const value, const char *const parentKey, void *object), const char *parentKey, void *object);
+void nanojsonc_parse_array(const char *json, NanoJSONcCallback callback, const char *parentKey, void *object);
 
 /**
  * @brief Parse a JSON object and invoke a callback for each key-value pair.
@@ -79,15 +87,16 @@ void nanojsonc_parse_array(const char *json, void (*callback)(const char *const 
  *
  * The callback function should have the following signature:
  * @code
- * void callback(const char *const key, const char *const value,
- *               const char *const parentKey, void *object);
+ * int callback(const char *const error, const char *const key, 
+ *               const char *const value, const char *const parentKey, void *object);
  * @endcode
  *
  * @note The provided callback function should handle the processing or population
- *       of the object based on the parsed JSON key-value pairs.
+ *       of the object based on the parsed JSON elements. If the callback returns
+ *       a non-zero value, the parsing process will be aborted.
  *
  * @see nanojsonc_parse_array
  */
-void nanojsonc_parse_object(const char *json, void (*callback)(const char *const key, const char *const value, const char *const parentKey, void *object), const char *parentKey, void *object);
+void nanojsonc_parse_object(const char *json, NanoJSONcCallback callback, const char *parentKey, void *object);
 
 #endif //NANOJSONC_PARSER_H

--- a/test/test_array.c
+++ b/test/test_array.c
@@ -36,12 +36,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 int counter = 0;
 
-static void callback1(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback1(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "hobbies") == 0) {
         if (strcmp(key, "[0]") == 0) { assert(strcmp(value, "Reading") == 0); counter++; }
         if (strcmp(key, "[1]") == 0) { assert(strcmp(value, "Hiking") == 0); counter++; }
         if (strcmp(key, "[2]") == 0) { assert(strcmp(value, "Cooking") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testStringArray() {
@@ -51,7 +53,8 @@ static void testStringArray() {
     counter = 0;
 }
 
-static void callback2(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback2(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "numbers") == 0) {
         if (strcmp(key, "[0]") == 0) { assert(strcmp(value, "1") == 0); counter++; }
         if (strcmp(key, "[1]") == 0) { assert(strcmp(value, "22") == 0); counter++; }
@@ -59,6 +62,7 @@ static void callback2(const char *const key, const char *const value, const char
         if (strcmp(key, "[3]") == 0) { assert(strcmp(value, "4444") == 0); counter++; }
         if (strcmp(key, "[4]") == 0) { assert(strcmp(value, "55555") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testNumberArray() {
@@ -68,8 +72,10 @@ static void testNumberArray() {
     counter = 0;
 }
 
-static void callback3(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback3(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     counter++;
+    return 0;
 }
 
 static void testEmptyArray() {
@@ -83,10 +89,12 @@ static void testEmptyArray() {
     assert(counter == 0);
 }
 
-static void callback4(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback4(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "single") == 0) {
         if(strcmp(key, "[0]") == 0) { assert(strcmp(value, "2023") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testSingleItemArray() {
@@ -96,12 +104,14 @@ static void testSingleItemArray() {
     counter = 0;
 }
 
-static void callback5(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback5(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "boolean") == 0) {
         if(strcmp(key, "[0]") == 0) { assert(strcmp(value, "true") == 0); counter++; }
         if(strcmp(key, "[1]") == 0) { assert(strcmp(value, "false") == 0); counter++; }
         if(strcmp(key, "[2]") == 0) { assert(strcmp(value, "true") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testBooleanArray() {
@@ -111,12 +121,14 @@ static void testBooleanArray() {
     counter = 0;
 }
 
-static void callback6(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback6(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "Null") == 0) {
         if(strcmp(key, "[0]") == 0) { assert(strcmp(value, "null") == 0); counter++; }
         if(strcmp(key, "[1]") == 0) { assert(strcmp(value, "null") == 0); counter++; }
         if(strcmp(key, "[2]") == 0) { assert(strcmp(value, "null") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testNullArray() {
@@ -126,10 +138,12 @@ static void testNullArray() {
     counter = 0;
 }
 
-static void callback7(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback7(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "single[0]") == 0) {
         if(strcmp(key, "i") == 0) { assert(strcmp(value, "4") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testSingleObjectArray() {
@@ -139,7 +153,8 @@ static void testSingleObjectArray() {
     counter = 0;
 }
 
-static void callback8(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback8(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "multiple[0]") == 0) {
         if (strcmp(key, "a") == 0) { assert(strcmp(value, "1") == 0); counter++; }
         if (strcmp(key, "b") == 0) { assert(strcmp(value, "2") == 0); counter++; }
@@ -148,6 +163,7 @@ static void callback8(const char *const key, const char *const value, const char
         if (strcmp(key, "a") == 0) { assert(strcmp(value, "3") == 0); counter++; }
         if (strcmp(key, "b") == 0) { assert(strcmp(value, "4") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testMultipleObjectsArray() {
@@ -157,7 +173,8 @@ static void testMultipleObjectsArray() {
     counter = 0;
 }
 
-static void callback9(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback9(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "boolean[0]") == 0) {
         if (strcmp(key, "[0]") == 0) { assert(strcmp(value, "true") == 0); counter++; }
         if (strcmp(key, "[1]") == 0) { assert(strcmp(value, "false") == 0); counter++; }
@@ -167,6 +184,7 @@ static void callback9(const char *const key, const char *const value, const char
         if (strcmp(key, "[0]") == 0) { assert(strcmp(value, "false") == 0); counter++; }
         if (strcmp(key, "[1]") == 0) { assert(strcmp(value, "false") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testNestedArray() { // has to be parsed list, not whole values
@@ -176,7 +194,8 @@ static void testNestedArray() { // has to be parsed list, not whole values
     counter = 0;
 }
 
-static void callback10(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback10(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "mixed") == 0) {
         if (strcmp(key, "[0]") == 0) { assert(strcmp(value, "Reading") == 0); counter++; }
         if (strcmp(key, "[1]") == 0) { assert(strcmp(value, "2020") == 0); counter++; }
@@ -187,6 +206,7 @@ static void callback10(const char *const key, const char *const value, const cha
         if (strcmp(key, "a") == 0) { assert(strcmp(value, "1") == 0); counter++; }
         if (strcmp(key, "b") == 0) { assert(strcmp(value, "2") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testMixedArray() {
@@ -196,7 +216,8 @@ static void testMixedArray() {
     counter = 0;
 }
 
-static void callback11(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback11(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "data[0][name]") == 0) {
         if (strcmp(key, "first") == 0) { assert(strcmp(value, "Janie") == 0); counter++; }
         if (strcmp(key, "last") == 0) { assert(strcmp(value, "Doe") == 0); counter++; }
@@ -204,6 +225,7 @@ static void callback11(const char *const key, const char *const value, const cha
     if (strcmp(parentKey, "data[0]") == 0) {
         if (strcmp(key, "age") == 0) { assert(atoi(value) == 13); counter++; }
     }
+    return 0;
 }
 
 static void testNestedObject() {
@@ -213,7 +235,8 @@ static void testNestedObject() {
     counter = 0;
 }
 
-static void callback12(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback12(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "data") == 0) {
         if (strcmp(key, "[0]") == 0) { assert(strcmp(value, "k") == 0); counter++; }
     } else if (strcmp(parentKey, "data[1]") == 0) {
@@ -230,6 +253,7 @@ static void callback12(const char *const key, const char *const value, const cha
     } else if (strcmp(parentKey, "data[2][2][3]") == 0) {
         if (strcmp(key, "[0]") == 0) { assert(strcmp(value, "j") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testDeepNestedArray() {

--- a/test/test_object.c
+++ b/test/test_object.c
@@ -35,8 +35,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 int counter = 0;
 
-static void callback(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     counter++;
+    return 0;
 }
 
 static void testEmptyObject() {
@@ -50,10 +52,12 @@ static void testEmptyObject() {
     assert(counter == 0);
 }
 
-static void callback1(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback1(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(key, "first") == 0) { assert(strcmp(value, "John") == 0); counter++; }
     if (strcmp(key, "last") == 0) { assert(strcmp(value, "Doe") == 0); counter++; }
     if (strcmp(key, "phone") == 0) { assert(strcmp(value, "") == 0); counter++; }
+    return 0;
 }
 
 static void testStringProperty() {
@@ -63,10 +67,12 @@ static void testStringProperty() {
     counter = 0;
 }
 
-static void callback2(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback2(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(key, "first") == 0) { assert(strcmp(value, "John") == 0); counter++; }
     if (strcmp(key, "last") == 0) { assert(strcmp(value, "Doe") == 0); counter++; }
     if (strcmp(key, "age") == 0) { assert(strcmp(value, "15") == 0); counter++; }
+    return 0;
 }
 
 static void testNumberProperty() {
@@ -76,11 +82,13 @@ static void testNumberProperty() {
     counter = 0;
 }
 
-static void callback3(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback3(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(key, "first") == 0) { assert(strcmp(value, "John") == 0); counter++; }
     if (strcmp(key, "last") == 0) { assert(strcmp(value, "Doe") == 0); counter++; }
     if (strcmp(key, "isMarried") == 0) { assert(strcmp(value, "false") == 0); counter++; }
     if (strcmp(key, "isEmployed") == 0) { assert(strcmp(value, "true") == 0); counter++; }
+    return 0;
 }
 
 static void testBooleanProperty() {
@@ -90,10 +98,12 @@ static void testBooleanProperty() {
     counter = 0;
 }
 
-static void callback4(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback4(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(key, "first") == 0) { assert(strcmp(value, "John") == 0); counter++; }
     if (strcmp(key, "last") == 0) { assert(strcmp(value, "Doe") == 0); counter++; }
     if (strcmp(key, "phone") == 0) { assert(strcmp(value, "null") == 0); counter++; }
+    return 0;
 }
 
 static void testNullValue() {
@@ -103,7 +113,8 @@ static void testNullValue() {
     counter = 0;
 }
 
-static void callback5(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback5(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "") == 0) {
         if (strcmp(key, "first") == 0) { assert(strcmp(value, "John") == 0); counter++; }
         if (strcmp(key, "age") == 0) { assert(strcmp(value, "15") == 0); counter++; }
@@ -113,6 +124,7 @@ static void callback5(const char *const key, const char *const value, const char
         if (strcmp(key, "[1]") == 0) { assert(strcmp(value, "Hiking") == 0); counter++; }
         if (strcmp(key, "[2]") == 0) { assert(strcmp(value, "Cooking") == 0); counter++; }
     }
+    return 0;
 }
 
 static void testArrayProperty() {
@@ -122,7 +134,8 @@ static void testArrayProperty() {
     counter = 0;
 }
 
-static void callback6(const char *const key, const char *const value, const char *const parentKey, void *object) {
+static int callback6(const char *const error, const char *const key, const char *const value, const char *const parentKey, void *object) {
+    assert(!error);
     if (strcmp(parentKey, "") == 0) {
         if (strcmp(key, "foo") == 0) { assert(strcmp(value, "bar") == 0); counter++; }
     }
@@ -139,6 +152,7 @@ static void callback6(const char *const key, const char *const value, const char
         assert(strcmp(value, "value3") == 0);
         counter++;
     }
+    return 0;
 }
 
 static void testDeepNested() {


### PR DESCRIPTION
### What this PR adds
- Some clang and vscode specific excludes in the .gitignore as well as common build directory name.
- Typedefs for callbacks. I did this becuase the method signatures where getting very large with multiple callbacks.
- An optional error handling callback that can be used instead of having them be printed to stderr.
- KEY_SIZE and VALUE_SIZE were renamed to NANOJSONC_KEY_SIZE and NANOJSONC_VALUE_SIZE. And warped inside of #ifndefs. This way a custom max buffer sizes can be at compile time. (Something that may be considered is a header only implementation. This way these can be defined before include and not need to be set as a compiler option.)
- Added some more error checking to prevent silent failures when the key or value is too large for the buffer


A bit of background, I am currently in the process of implementing this JSON parser in my project. I am working on a pure C game engine and I plan on using JSON as the project settings file format (at least for now). The engine has its own error handling and printing out to std error is not the best of solutions for me. And silent failures when the key and or value is too large can make a bad experience for the end user.

Example code:
```
gcc -g demo.c src/*.c -Iinclude/ -g -D NANOJSONC_KEY_SIZE=4
```
```c
#include "parser.h"
#include <assert.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

struct Person {
    char *name;
    int age;
};

static void callback(const char *const key, const char *const value, const char *const parentKey, void *object) {
    struct Person **person = object;
    if (*person == NULL) {
        *person = malloc(sizeof(struct Person));
        **person = (struct Person){0};
    }
    if (strcmp(key, "name") == 0) (*person)->name = strdup(value);
    if (strcmp(key, "age") == 0) (*person)->age = atoi(value);
}

static void errorCallback(const char *const message, const char *const json, const char *const parentKey, void *object) {
    fprintf(stderr, "Error: %s\n", message);
    fprintf(stderr, "JSON: %s\n", json);
    fprintf(stderr, "Parent Key: %s\n", parentKey);

    exit(EXIT_FAILURE);
}

int main(void) {
    char *json = "{\"name\": \"John Doe\", \"age\": 25}";

    struct Person *person = NULL;
    nanojsonc_parse_object(json, callback, NULL, &person, errorCallback);

    assert(person->name);
    assert(strcmp(person->name, "John Doe") == 0);
    assert(person->age == 25);

    printf("Name: %s, Age: %d", person->name, person->age);
    free(person->name);
    free(person);
    return 0;
}
```

